### PR TITLE
fix: add type object to Pet in petstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rpc/examples",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "OpenRPC examples package. It exports JSON as a js module.",
   "main": "index.js",
   "scripts": {

--- a/service-descriptions/petstore-openrpc.json
+++ b/service-descriptions/petstore-openrpc.json
@@ -112,6 +112,7 @@
   "components": {
     "schemas": {
       "Pet": {
+        "type": "object",
         "required": [
           "id",
           "name"


### PR DESCRIPTION
`"type": "object"` is required for JSON Schema objects with `properties`.

I have a a test failing in client-generator for this