### PR TITLE
fix: dependabot should run in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
       only: master
   - &filter-only-semantic-pr
     branches:
-      only:  /^(fix|feat)\/.*$/
+      only:  /^(dependabot|fix|feat)\/.*$/
 
 defaults: &defaults
   working_directory: ~/examples


### PR DESCRIPTION
fixes #63 