### PR TITLE
fix: fill out link example

### DIFF
--- a/service-descriptions/link-example-openrpc.json
+++ b/service-descriptions/link-example-openrpc.json
@@ -195,6 +195,13 @@
   "components": {
     "links": {
       "UserRepositories": {
+        "description": "Get the repositories by owner.",
+        "summary": "Get the repos by owner",
+        "server":{
+          "name": "Other Server Name",
+          "description": "Use other server instead",
+          "url": "http://localhost:9210"
+        },
         "method": "get_repositories_by_owner",
         "params": {
           "username": "$result.username"


### PR DESCRIPTION
fixes #75

tests will fail until `LinkObject.summary` is in meta-schema: https://github.com/open-rpc/meta-schema/issues/75