### PR TITLE
fix: Renamed simpleMathAdditionTwo example

### DIFF
--- a/service-descriptions/simple-math-openrpc.json
+++ b/service-descriptions/simple-math-openrpc.json
@@ -47,7 +47,7 @@
           "result": { "$ref": "#/components/examples/integerFour" }
         },
         {
-          "name": "simpleMathAdditionTwo",
+          "name": "simpleMathAdditionFour",
           "params": [
             { "$ref": "#/components/examples/integerFour" },
             { "$ref": "#/components/examples/integerFour" }


### PR DESCRIPTION
#131 